### PR TITLE
Implement the View.toBrowserDocument function

### DIFF
--- a/src/View.elm
+++ b/src/View.elm
@@ -1,5 +1,6 @@
 module View exposing (View, map, none, placeholder, toBrowserDocument)
 
+import Browser
 import Element exposing (..)
 
 
@@ -28,5 +29,8 @@ map fn view =
     }
 
 
-toBrowserDocument =
-    identity
+toBrowserDocument : View msg -> Browser.Document msg
+toBrowserDocument view =
+    { title = view.title
+    , body = [ Element.layout [] view.body ]
+    }


### PR DESCRIPTION
Before this patch, "elm-spa make" will give an error message.
With this fix, "elm-spa make" succeeds, and "lamdera live" works.

$ elm-spa make

-- TYPE MISMATCH ------------------------ .elm-spa/defaults/Main.elm

Something is off with the body of the `view` definition:

130|>    Pages.view model.page model.shared model.url model.key
131|>        |> View.map Page
132|>        |> View.toBrowserDocument

The body is:

    View.View Msg

But the type annotation on `view` says it should be:

    { body : List (Html.Html Msg), title : String }

ps: This is my first pull-request, did I do it right?